### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/server/routes/predict.js
+++ b/server/routes/predict.js
@@ -89,10 +89,15 @@ async function cleanupFile(filePath) {
   try {
     // Ensure the file is within the upload directory
     const resolvedPath = path.resolve(filePath);
-    if (!resolvedPath.startsWith(path.resolve(UPLOAD_DIR) + path.sep)) {
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR);
+    const relativePath = path.relative(resolvedUploadDir, resolvedPath);
+    
+    // Check if the path is outside the upload directory (starts with '..' or is absolute)
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
       console.warn(`警告: アップロードディレクトリ外のファイル削除要求: ${resolvedPath}`);
       return;
     }
+    
     await fs.unlink(resolvedPath);
   } catch (error) {
     console.error('ファイルの清掃エラー:', error.message);

--- a/server/routes/predict.js
+++ b/server/routes/predict.js
@@ -2,6 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs').promises;
+const UPLOAD_DIR = path.join(__dirname, '..', 'uploads');
 const { spawn } = require('child_process');
 const router = express.Router();
 const storage = multer.diskStorage({
@@ -86,7 +87,13 @@ function callPythonScript(imagePath) {
 
 async function cleanupFile(filePath) {
   try {
-    await fs.unlink(filePath);
+    // Ensure the file is within the upload directory
+    const resolvedPath = path.resolve(filePath);
+    if (!resolvedPath.startsWith(path.resolve(UPLOAD_DIR) + path.sep)) {
+      console.warn(`警告: アップロードディレクトリ外のファイル削除要求: ${resolvedPath}`);
+      return;
+    }
+    await fs.unlink(resolvedPath);
   } catch (error) {
     console.error('ファイルの清掃エラー:', error.message);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/yue4521/digit-recognizer/security/code-scanning/1](https://github.com/yue4521/digit-recognizer/security/code-scanning/1)

To fix the problem, we need to ensure that the file path passed to `cleanupFile` is always within the intended upload directory. This can be done by normalizing the path and checking that it starts with the upload directory path before performing the deletion. Specifically, in `cleanupFile`, we should resolve the file path and compare its prefix to the upload directory. If the file is outside the upload directory, skip deletion and log a warning. This change should be made in the `cleanupFile` function in `server/routes/predict.js`. We need to define the upload directory path at the top of the file for consistency.

**Required changes:**
- Define the upload directory path as a constant.
- In `cleanupFile`, resolve the file path and check that it is within the upload directory before deleting.
- Log a warning if the file is outside the upload directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
