### PR TITLE
fix(ci): GitHub ActionsのTruffleHogエラーを修正

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -128,10 +128,16 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSSでシークレットスキャン実行
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          extra_args: --debug --only-verified --json --output=trufflehog-report.json
+        run: |
+          # workflow_dispatchやscheduleイベントの場合は、git scanではなくfilesystem scanを使用
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Running filesystem scan for ${{ github.event_name }} event"
+            docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:latest filesystem /pwd --json --output=/pwd/trufflehog-report.json || true
+          else
+            echo "Running git scan for ${{ github.event_name }} event"
+            # push/pull_requestイベントの場合は、TruffleHog actionを使用
+            docker run --rm -v "$PWD:/pwd" -w /pwd trufflesecurity/trufflehog:latest git file:///pwd/ --json --output=/pwd/trufflehog-report.json || true
+          fi
         continue-on-error: true
 
       - name: シークレットスキャン結果のアップロード

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -131,13 +131,7 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: main
-          head: HEAD
-          extra_args: --debug --only-verified
-
-      - name: TruffleHog結果のJSON出力
-        run: |
-          docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:latest filesystem /pwd --json > trufflehog-report.json || true
+          extra_args: --debug --only-verified --json --output=trufflehog-report.json
         continue-on-error: true
 
       - name: シークレットスキャン結果のアップロード


### PR DESCRIPTION
## Summary
- TruffleHogのBASE=HEADエラーを修正
- イベントタイプ別に適切なスキャン方式を使用
- workflow_dispatch/scheduleではfilesystem scan、push/pull_requestではgit scanを実行

## Test plan
- [x] workflow_dispatchでの手動実行をテスト
- [ ] push eventでのテストを実行  
- [ ] 全てのセキュリティジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)